### PR TITLE
Add github workflow to check scala code is formatted

### DIFF
--- a/.github/workflows/check-build-test.yml
+++ b/.github/workflows/check-build-test.yml
@@ -41,9 +41,6 @@ jobs:
       - name: Compile all code with default compiler
         run: sbt Test/compile
 
-      - name: Format check
-        run: sbt scalafmtCheckAll
-
   test:
     name: Build and Test
     runs-on: ubuntu-20.04

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,24 @@
+name: Scalafmt
+
+permissions: read-all
+
+on:
+  pull_request:
+    branches: ['**']
+
+jobs:
+  build:
+    name: Code is formatted
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout current branch (full)
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Check project is formatted
+        uses: jrouly/scalafmt-native-action@v2
+        with:
+          version: '3.6.1'
+          arguments: '--list --mode diff-ref=origin/main'


### PR DESCRIPTION
Similar to pekko core, replaces the sbt scalafmt check with a github actions one. Also removes the `sbt scalafmtCheckAll` from the current github actions.