### PR TITLE
Add .git-blame-ignore-revs file containing format commits

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# scalafmt
+5974c87e40c0db5ab3f2109d29db720fa1aeebb8


### PR DESCRIPTION
Similar to pekko core, adds a .git-blame-ignore-revs which contains the hashes for the previous scalafmt commits.