### PR TITLE
import sbt-ci-release plugin because it is needed by sbt-apache-sonatype

### DIFF
--- a/project/Publish.scala
+++ b/project/Publish.scala
@@ -16,16 +16,13 @@ import sbt._
 import sbt.Keys._
 
 import java.io.File
-import sbtrelease.ReleasePlugin.autoImport.releasePublishArtifactsAction
 import org.mdedetrich.apache.sonatype.SonatypeApachePlugin
 import SonatypeApachePlugin.autoImport.apacheSonatypeDisclaimerFile
 
 object Publish extends AutoPlugin {
 
-  val defaultPublishTo = settingKey[File]("Default publish directory")
-
   override def trigger = allRequirements
-  override def requires = sbtrelease.ReleasePlugin && SonatypeApachePlugin
+  override def requires = SonatypeApachePlugin
 
   override lazy val projectSettings = Seq(
     crossPaths := false,
@@ -33,7 +30,11 @@ object Publish extends AutoPlugin {
     credentials ++= apacheNexusCredentials,
     homepage := Some(url("https://github.com/apache/incubator-pekko-persistence-dynamodb")),
     pomIncludeRepository := { x => false },
-    defaultPublishTo := crossTarget.value / "repository",
+    publishTo := {
+      val nexus = s"https://${apacheBaseRepo}/"
+      if (isSnapshot.value) Some("snapshots" at nexus + "content/repositories/snapshots")
+      else Some("releases" at nexus + "service/local/staging/deploy/maven2")
+    },
     apacheSonatypeDisclaimerFile := Some((LocalRootProject / baseDirectory).value / "DISCLAIMER"))
 
   def pekkoPomExtra = {

--- a/project/Publish.scala
+++ b/project/Publish.scala
@@ -26,35 +26,17 @@ object Publish extends AutoPlugin {
 
   override lazy val projectSettings = Seq(
     crossPaths := false,
-    pomExtra := pekkoPomExtra,
-    credentials ++= apacheNexusCredentials,
     homepage := Some(url("https://github.com/apache/incubator-pekko-persistence-dynamodb")),
-    pomIncludeRepository := { x => false },
     publishTo := {
       val nexus = s"https://${apacheBaseRepo}/"
       if (isSnapshot.value) Some("snapshots".at(nexus + "content/repositories/snapshots"))
       else Some("releases".at(nexus + "service/local/staging/deploy/maven2"))
     },
+    developers += Developer("contributors",
+      "Contributors",
+      "dev@pekko.apache.org",
+      url("https://github.com/apache/incubator-pekko-persistence-dynamodb/graphs/contributors")),
     apacheSonatypeDisclaimerFile := Some((LocalRootProject / baseDirectory).value / "DISCLAIMER"))
 
-  def pekkoPomExtra = {
-    <developers>
-      <developer>
-        <id>contributors</id>
-        <name>Contributors</name>
-        <email>dev@pekko.apache.org</email>
-        <url>https://github.com/apache/incubator-pekko-persistence-dynamodb/graphs/contributors</url>
-      </developer>
-    </developers>
-  }
-
   private val apacheBaseRepo = "repository.apache.org"
-
-  private def apacheNexusCredentials: Seq[Credentials] =
-    (sys.env.get("NEXUS_USER"), sys.env.get("NEXUS_PW")) match {
-      case (Some(user), Some(password)) =>
-        Seq(Credentials("Sonatype Nexus Repository Manager", apacheBaseRepo, user, password))
-      case _ =>
-        Seq.empty
-    }
 }

--- a/project/Publish.scala
+++ b/project/Publish.scala
@@ -15,7 +15,6 @@ package org.apache.pekko
 import sbt._
 import sbt.Keys._
 
-import java.io.File
 import org.mdedetrich.apache.sonatype.SonatypeApachePlugin
 import SonatypeApachePlugin.autoImport.apacheSonatypeDisclaimerFile
 
@@ -27,16 +26,9 @@ object Publish extends AutoPlugin {
   override lazy val projectSettings = Seq(
     crossPaths := false,
     homepage := Some(url("https://github.com/apache/incubator-pekko-persistence-dynamodb")),
-    publishTo := {
-      val nexus = s"https://${apacheBaseRepo}/"
-      if (isSnapshot.value) Some("snapshots".at(nexus + "content/repositories/snapshots"))
-      else Some("releases".at(nexus + "service/local/staging/deploy/maven2"))
-    },
     developers += Developer("contributors",
       "Contributors",
       "dev@pekko.apache.org",
       url("https://github.com/apache/incubator-pekko-persistence-dynamodb/graphs/contributors")),
     apacheSonatypeDisclaimerFile := Some((LocalRootProject / baseDirectory).value / "DISCLAIMER"))
-
-  private val apacheBaseRepo = "repository.apache.org"
 }

--- a/project/Publish.scala
+++ b/project/Publish.scala
@@ -32,8 +32,8 @@ object Publish extends AutoPlugin {
     pomIncludeRepository := { x => false },
     publishTo := {
       val nexus = s"https://${apacheBaseRepo}/"
-      if (isSnapshot.value) Some("snapshots" at nexus + "content/repositories/snapshots")
-      else Some("releases" at nexus + "service/local/staging/deploy/maven2")
+      if (isSnapshot.value) Some("snapshots".at(nexus + "content/repositories/snapshots"))
+      else Some("releases".at(nexus + "service/local/staging/deploy/maven2"))
     },
     apacheSonatypeDisclaimerFile := Some((LocalRootProject / baseDirectory).value / "DISCLAIMER"))
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,6 @@
 resolvers += "Typesafe repository".at("https://repo.typesafe.com/typesafe/releases/")
 
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.9.0")
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.9")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1")
 addSbtPlugin("com.lightbend" % "sbt-whitesource" % "0.1.7")
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.9.3")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,5 +6,4 @@ addSbtPlugin("com.lightbend" % "sbt-whitesource" % "0.1.7")
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.9.3")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.6")
 addSbtPlugin("org.mdedetrich" % "sbt-apache-sonatype" % "0.1.5")
-// https://github.com/dwijnand/sbt-dynver
-addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
+addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.10")


### PR DESCRIPTION
https://github.com/apache/incubator-pekko-persistence-dynamodb/actions/runs/4379924085 failed - but when I tested locally, this change made the publish get as far as sending the files to the Apache Nexus server but getting a 401 because I had no credentials set up.