### PR TITLE
Make dynver append -SNAPSHOT to snaphots

### DIFF
--- a/project/Publish.scala
+++ b/project/Publish.scala
@@ -14,14 +14,15 @@ package org.apache.pekko
 
 import sbt._
 import sbt.Keys._
-
 import org.mdedetrich.apache.sonatype.SonatypeApachePlugin
 import SonatypeApachePlugin.autoImport.apacheSonatypeDisclaimerFile
+import sbtdynver.DynVerPlugin
+import sbtdynver.DynVerPlugin.autoImport.dynverSonatypeSnapshots
 
 object Publish extends AutoPlugin {
 
   override def trigger = allRequirements
-  override def requires = SonatypeApachePlugin
+  override def requires = SonatypeApachePlugin && DynVerPlugin
 
   override lazy val projectSettings = Seq(
     crossPaths := false,
@@ -31,4 +32,7 @@ object Publish extends AutoPlugin {
       "dev@pekko.apache.org",
       url("https://github.com/apache/incubator-pekko-persistence-dynamodb/graphs/contributors")),
     apacheSonatypeDisclaimerFile := Some((LocalRootProject / baseDirectory).value / "DISCLAIMER"))
+
+  override lazy val buildSettings = Seq(
+    dynverSonatypeSnapshots := true)
 }


### PR DESCRIPTION
Turns out that if you use sbt-dynver directly you need to explicitly set it to add `-SNAPSHOT` to the artifact name if you are currently dealing with a snapshot which is why the last publish failed.

This is also what sbt-ci-release does (see https://github.com/sbt/sbt-ci-release/blob/0dad9ee3ab99c6f78493e2de3bc1364ecf3b9c00/plugin/src/main/scala/com/geirsson/CiReleasePlugin.scala#L108)