### PR TITLE
Remove un-needed sonatypeBundleRelease

### DIFF
--- a/.github/workflows/publish-nightly.yml
+++ b/.github/workflows/publish-nightly.yml
@@ -46,7 +46,7 @@ jobs:
         env:
           NEXUS_USER: ${{ secrets.NEXUS_USER }}
           NEXUS_PW: ${{ secrets.NEXUS_PW }}
-        run: sbt +publish sonatypeBundleRelease
+        run: sbt +publish
 
       - name: Cache Coursier cache
         uses: coursier/cache-action@v6.4.0


### PR DESCRIPTION
So it turns out that the explicit `sonatypeBundleRelease` is not used for snapshots and the reason why the bundle release was being triggered beforehand is that the `-SNAPSHOT` wasn't being appended to the artifact correctly which was resolved in https://github.com/apache/incubator-pekko-persistence-dynamodb/pull/25)

The last nightly manually trigger did actually successfully publish to Apache snapshots repo (see https://repository.apache.org/content/groups/snapshots/org/apache/pekko/pekko-persistence-dynamodb_2.12/), its just the subsequent `sonatypeBundleRelease` command failed.