### PR TITLE
fix some deprecation issues

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -29,6 +29,7 @@ libraryDependencies ++= Seq(
   "org.hdrhistogram" % "HdrHistogram" % "2.1.8" % "test",
   "com.dimafeng" %% "testcontainers-scala-scalatest" % testcontainersScalaVersion % "test")
 
+scalacOptions ++= Seq("-deprecation", "-feature")
 Test / parallelExecution := false
 // required by test-containers-scala
 Test / fork := true

--- a/src/main/scala/org/apache/pekko/persistence/dynamodb/journal/DynamoDBHelper.scala
+++ b/src/main/scala/org/apache/pekko/persistence/dynamodb/journal/DynamoDBHelper.scala
@@ -53,7 +53,7 @@ trait DynamoDBHelper {
     def name = d.desc(aws)
 
     def sendSingle(): Future[Out] = {
-      val p = Promise[Out]
+      val p = Promise[Out]()
 
       val handler = new AsyncHandler[In, Out] {
         override def onError(ex: Exception) =

--- a/src/main/scala/org/apache/pekko/persistence/dynamodb/journal/DynamoDBJournal.scala
+++ b/src/main/scala/org/apache/pekko/persistence/dynamodb/journal/DynamoDBJournal.scala
@@ -152,7 +152,7 @@ class DynamoDBJournal(config: Config)
       for {
         lowest <- lowF
         highest <- highF
-        val upTo = Math.min(toSequenceNr, highest)
+        upTo = Math.min(toSequenceNr, highest)
         _ <- if (upTo + 1 > lowest) setLS(persistenceId, to = upTo + 1) else Future.successful(Done)
         _ <- if (lowest <= upTo) deleteMessages(persistenceId, lowest, upTo) else Future.successful(Done)
       } yield {

--- a/src/main/scala/org/apache/pekko/persistence/dynamodb/package.scala
+++ b/src/main/scala/org/apache/pekko/persistence/dynamodb/package.scala
@@ -41,13 +41,13 @@ package object dynamodb {
   def B(value: Array[Byte]): AttributeValue = new AttributeValue().withB(ByteBuffer.wrap(value))
 
   def lift[T](f: Future[T]): Future[Try[T]] = {
-    val p = Promise[Try[T]]
+    val p = Promise[Try[T]]()
     f.onComplete(p.success)(ExecutionContexts.sameThreadExecutionContext)
     p.future
   }
 
   def liftUnit(f: Future[Any]): Future[Try[Unit]] = {
-    val p = Promise[Try[Unit]]
+    val p = Promise[Try[Unit]]()
     f.onComplete {
       case Success(_)     => p.success(Success(()))
       case f @ Failure(_) => p.success(f.asInstanceOf[Failure[Unit]])


### PR DESCRIPTION
* this is the tip of the iceberg
* this leaves some Pekko related deprecations
* leaves some Scala related deprecations (which might not be easy to fix while we need to support Scala 2.12)
* numerous Amazon deprecations still