### PR TITLE
Remove IntegrationTest

### DIFF
--- a/project/CopyrightHeader.scala
+++ b/project/CopyrightHeader.scala
@@ -23,7 +23,7 @@ trait CopyrightHeader extends AutoPlugin {
   override def trigger: PluginTrigger = allRequirements
 
   protected def headerMappingSettings: Seq[Def.Setting[_]] =
-    Seq(Compile, Test, IntegrationTest).flatMap { config =>
+    Seq(Compile, Test).flatMap { config =>
       inConfig(config)(
         Seq(
           headerLicense := Some(HeaderLicense.Custom(apacheHeader)),
@@ -35,8 +35,7 @@ trait CopyrightHeader extends AutoPlugin {
     }
 
   override def projectSettings: Seq[Def.Setting[_]] =
-    Def.settings(headerMappingSettings, additional) ++ Defaults.itSettings ++
-    headerSettings(IntegrationTest)
+    Def.settings(headerMappingSettings, additional)
 
   def additional: Seq[Def.Setting[_]] =
     Def.settings(Compile / compile := {


### PR DESCRIPTION
Resolves: https://github.com/apache/incubator-pekko-persistence-dynamodb/issues/39

Removes `IntegrationTest` because its now deprecated. Thankfully this change is quite trivial because it just so happens that r2dbc doesn't have any tests that use `IntegrationTest` scope. 