### PR TITLE
Use proper type for SemVerSpec

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ val testcontainersScalaVersion = "0.40.10"
 resolvers += Resolver.ApacheMavenSnapshotsRepo
 
 ThisBuild / apacheSonatypeProjectProfile := "pekko"
-ThisBuild / versionScheme := Some("semver-spec")
+ThisBuild / versionScheme := Some(VersionScheme.SemVerSpec)
 sourceDistName := "incubating-pekko-persistence-dynamodb"
 
 Test / unmanagedSourceDirectories ++= {


### PR DESCRIPTION
There is an actual proper type for `SemVerSpec` which is better than using a `String`.