### PR TITLE
use older version of dynamodb docker image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   dynamodb:
-    image: amazon/dynamodb-local
+    image: amazon/dynamodb-local:1.22.0
     ports:
       - '8000:8000' #DDB
     environment:

--- a/src/test/scala/org/apache/pekko/persistence/dynamodb/IntegSpec.scala
+++ b/src/test/scala/org/apache/pekko/persistence/dynamodb/IntegSpec.scala
@@ -19,7 +19,7 @@ import org.testcontainers.containers.wait.strategy.HttpWaitStrategy
 trait IntegSpec extends ForAllTestContainer { self: Suite =>
   // TODO: Use dynamic ports. This is a annoying to do as the actor system is init prior to beforeAll.
   override val container: FixedHostPortGenericContainer = FixedHostPortGenericContainer(
-    "amazon/dynamodb-local:latest",
+    "amazon/dynamodb-local:1.22.0",
     exposedContainerPort = 8000,
     exposedHostPort = 8888,
     waitStrategy = new HttpWaitStrategy().forPath("/").forStatusCode(400))


### PR DESCRIPTION
* our CI tests have started failing and it might be due to AWS releasing v2.0 of this docker image a couple of weeks ago.
* relates to #59 