### PR TITLE
enable wiki

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -16,7 +16,7 @@ github:
 
   features:
     # Enable wiki for documentation
-    wiki: false
+    wiki: true
     # Enable issue management
     issues: true
     # Enable projects for project management boards


### PR DESCRIPTION
This project has no paradox docs.

Someone might have time in the future to create them and to wire up the publishing.

In the mean time, we can use GitHub wiki for release notes etc.