### PR TITLE
Use fetch tags from latest checkout action

### DIFF
--- a/.github/workflows/check-build-test.yml
+++ b/.github/workflows/check-build-test.yml
@@ -20,9 +20,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          fetch-tags: true
 
       - name: Checkout GitHub merge
         if: github.event.pull_request
@@ -56,9 +57,10 @@ jobs:
           - { java-version: 11, scala-version: 2.13.11, sbt-opts: '-J-XX:+UnlockExperimentalVMOptions -J-XX:+UseJVMCICompiler' }
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          fetch-tags: true
 
       - name: Checkout GitHub merge
         if: github.event.pull_request

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -12,9 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout current branch (full)
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          fetch-tags: true
           persist-credentials: false
 
       - name: Check project is formatted

--- a/.github/workflows/headers.yml
+++ b/.github/workflows/headers.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Java 11
         uses: actions/setup-java@v3

--- a/.github/workflows/publish-nightly.yml
+++ b/.github/workflows/publish-nightly.yml
@@ -32,9 +32,10 @@ jobs:
     if: github.repository == 'apache/incubator-pekko-persistence-dynamodb'
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          fetch-tags: true
 
       - name: Setup Java 8
         uses: actions/setup-java@v3


### PR DESCRIPTION
The latest version of the checkout github actions now supports a `fetch-tags` flag which does as described, i.e. it will fetch all of our tags which removes the various workarounds that was used before (i.e. manually running `git fetch` command) etc etc, see https://github.com/actions/checkout/pull/579

This will also help in the erroneous errors that we get in CI, i.e. 

```
[error] Failed to derive version from git tags. Maybe run `git fetch --unshallow` or `git fetch upstream` on a fresh git clone from a fork? Derived version: 0.0.0+1-337943bd-SNAPSHOT`
```