### PR TITLE
Add -Yfuture-lazy-vals for Scala 3.3.x builds

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -53,7 +53,7 @@ lazy val root = Project(
       "com.dimafeng" %% "testcontainers-scala-scalatest" % testcontainersScalaVersion % Test),
     scalacOptions ++= Seq("-deprecation", "-feature"),
     scalacOptions ++= {
-      if (scalaBinaryVersion.value == "3") Seq("-Yfuture-lazy-vals")
+      if (scalaBinaryVersion.value == "3") Seq("-Yfuture-lazy-vals", "-release:17")
       else Seq.empty
     },
     Test / parallelExecution := false,

--- a/build.sbt
+++ b/build.sbt
@@ -52,6 +52,10 @@ lazy val root = Project(
       "org.hdrhistogram" % "HdrHistogram" % "2.2.2" % Test,
       "com.dimafeng" %% "testcontainers-scala-scalatest" % testcontainersScalaVersion % Test),
     scalacOptions ++= Seq("-deprecation", "-feature"),
+    scalacOptions ++= {
+      if (scalaBinaryVersion.value == "3") Seq("-Yfuture-lazy-vals")
+      else Seq.empty
+    },
     Test / parallelExecution := false,
     // required by test-containers-scala
     Test / fork := true,


### PR DESCRIPTION
### Motivation

The Scala 3.3.8 compiler introduced the `-Yfuture-lazy-vals` flag ([scala/scala3-lts#637](https://github.com/scala/scala3-lts/pull/637)) to optionally use `VarHandle` instead of `sun.misc.Unsafe` for lazy val implementation. This prepares libraries for upcoming JDK releases that restrict `sun.misc.Unsafe` access.

### Modification

Add `-Yfuture-lazy-vals` to scalacOptions, conditionally applied only for Scala 3.3.x.

### Result

Scala 3.3.x build uses the future-proof `VarHandle`-based lazy val implementation, compatible with all JDK 9+ versions including future releases that restrict `sun.misc.Unsafe`.

### References

Refs scala/scala3-lts#637
Refs apache/pekko#3059