### PR TITLE
chore: Rewrite to scala3 syntax

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,5 +1,5 @@
 version                                  = 3.11.1
-runner.dialect                           = scala213
+runner.dialect                           = scala213source3
 project.git                              = true
 style                                    = defaultWithAlign
 docstrings.style                         = Asterisk
@@ -72,3 +72,13 @@ rewriteTokens          = {
   "←": "<-"
 }
 project.layout         = StandardConvention
+
+rewrite.scala3.convertToNewSyntax = true
+runner {
+  dialectOverride {
+    allowSignificantIndentation = false
+    allowAsForImportRename = false
+    allowStarWildcardImport = false
+    allowPostfixStarVarargSplices = false
+  }
+}

--- a/project/CopyrightHeader.scala
+++ b/project/CopyrightHeader.scala
@@ -22,7 +22,7 @@ trait CopyrightHeader extends AutoPlugin {
 
   override def trigger: PluginTrigger = allRequirements
 
-  protected def headerMappingSettings: Seq[Def.Setting[_]] =
+  protected def headerMappingSettings: Seq[Def.Setting[?]] =
     Seq(Compile, Test).flatMap { config =>
       inConfig(config)(
         Seq(
@@ -34,10 +34,10 @@ trait CopyrightHeader extends AutoPlugin {
             HeaderFileType("template") -> cStyleComment)))
     }
 
-  override def projectSettings: Seq[Def.Setting[_]] =
+  override def projectSettings: Seq[Def.Setting[?]] =
     Def.settings(headerMappingSettings, additional)
 
-  def additional: Seq[Def.Setting[_]] =
+  def additional: Seq[Def.Setting[?]] =
     Def.settings(Compile / compile := {
         (Compile / headerCreate).value
         (Compile / compile).value

--- a/src/main/scala/org/apache/pekko/persistence/dynamodb/journal/DynamoDBHelper.scala
+++ b/src/main/scala/org/apache/pekko/persistence/dynamodb/journal/DynamoDBHelper.scala
@@ -78,7 +78,7 @@ trait DynamoDBHelper {
   def setReporter(ref: ActorRef): Unit = reporter = ref
 
   private def send[In <: AmazonWebServiceRequest, Out](aws: In, func: AsyncHandler[In, Out] => juc.Future[Out])(implicit
-      d: Describe[_ >: In]): Future[Out] = {
+      d: Describe[? >: In]): Future[Out] = {
 
     def name = d.desc(aws)
 

--- a/src/test/scala/org/apache/pekko/persistence/dynamodb/journal/DynamoDBIntegrationLoadSpec.scala
+++ b/src/test/scala/org/apache/pekko/persistence/dynamodb/journal/DynamoDBIntegrationLoadSpec.scala
@@ -53,7 +53,7 @@ pekko.persistence.snapshot-store.plugin = ""
     def receiveCommand: Receive = {
       case DeleteTo(sequenceNr) =>
         deleteMessages(sequenceNr)
-      case payload: List[_] =>
+      case payload: List[?] =>
         persistAll(payload)(handle)
     }
 

--- a/src/test/scala/org/apache/pekko/persistence/dynamodb/journal/FailureReportingSpec.scala
+++ b/src/test/scala/org/apache/pekko/persistence/dynamodb/journal/FailureReportingSpec.scala
@@ -206,7 +206,7 @@ pekko.loggers = ["org.apache.pekko.testkit.TestEventListener"]
     "have sensible error messages" when {
       val evaluatedDynamo = dynamo
       import evaluatedDynamo._
-      def desc[T](aws: T)(implicit d: Describe[_ >: T]): String = d.desc(aws)
+      def desc[T](aws: T)(implicit d: Describe[? >: T]): String = d.desc(aws)
 
       val keyItem = Map(Key -> S("TheKey"), Sort -> N("42")).asJava
       val key2Item = Map(Key -> S("The2Key"), Sort -> N("43")).asJava


### PR DESCRIPTION
### Motivation
Let Scala 3 Community build compile pekko-persistence-dynamodb.

### Modification
Update `.scalafmt.conf` dialect to `scala213source3` and enable Scala 3 syntax rewrite rules (`rewrite.scala3.convertToNewSyntax`), then reformat all sources. Key changes:
- Wildcard type `_` → `?` (e.g. `Class[_]` → `Class[?]`)

### Result
Code is compatible with Scala 3 compiler when built with the community build.

### Tests
Not run - formatting only

### References
Refs apache/pekko#3048