### PR TITLE
chore: unify formatter config - standardize aliases, add JDK17 setting

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,6 +19,11 @@ sourceDistIncubating := false
 
 ThisBuild / reproducibleBuildsCheckResolver := Resolver.ApacheMavenStagingRepo
 
+ThisBuild / javafmtFormatterCompatibleJavaVersion := 17
+
+addCommandAlias("checkCodeStyle", "scalafmtCheckAll; scalafmtSbtCheck; javafmtCheckAll; +headerCheckAll")
+addCommandAlias("applyCodeStyle", "+headerCreateAll; scalafmtAll; scalafmtSbt; javafmtAll")
+
 Test / unmanagedSourceDirectories ++= {
   if (scalaVersion.value.startsWith("2.")) {
     Seq(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -10,6 +10,7 @@
 addSbtPlugin("com.github.sbt" % "sbt-header" % "5.11.0")
 addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.3.1")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.6.1")
+addSbtPlugin("com.github.sbt" % "sbt-java-formatter" % "0.12.0")
 addSbtPlugin("com.github.pjfanning" % "sbt-source-dist" % "0.1.13")
 addSbtPlugin("com.github.pjfanning" % "sbt-pekko-build" % "0.4.7")
 addSbtPlugin("com.github.sbt" % "sbt-dynver" % "5.1.1")


### PR DESCRIPTION
### Motivation
Align formatter plugins, command aliases, and JDK settings with other pekko sub-projects to reduce maintenance burden and ensure consistent formatting configuration across the ecosystem.

### Modification
- Standardize `checkCodeStyle`/`applyCodeStyle` command aliases
- Add `ThisBuild / javafmtFormatterCompatibleJavaVersion := 17` where missing
- Replace custom `verifyCodeFmt` tasks with standard aliases where applicable
- Upgrade sbt-java-formatter plugin where needed

### Result
Consistent formatter configuration across all pekko sub-projects, enabling unified `sbt checkCodeStyle` / `sbt applyCodeStyle` workflow.

### Tests
Not run - build config change only

### References
None - formatter unification across pekko sub-projects