### PR TITLE
chore: unify formatter config - standardize aliases, add JDK17 setting

### DIFF
--- a/.github/workflows/check-build-test.yml
+++ b/.github/workflows/check-build-test.yml
@@ -11,6 +11,37 @@ on:
     tags-ignore: [ v.* ]
 
 jobs:
+  check-code-style:
+    name: Check Code Style
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Checkout GitHub merge
+        if: github.event.pull_request
+        run: |-
+          git fetch origin pull/${{ github.event.pull_request.number }}/merge:scratch
+          git checkout scratch
+
+      - name: Setup Java 17
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Install sbt
+        uses: sbt/setup-sbt@af116cce31c00823d3903ce687f9cda3a4f19f1b # v1.2.1
+
+      - name: Cache Coursier cache
+        uses: coursier/cache-action@95e5b1029b6b86e7bac033ee44a0697d8a527d2d # v8.1.1
+
+      - name: Code style check
+        run: sbt checkCodeStyle
+
   check-code-compilation:
     name: Check Code Compilation
     runs-on: ubuntu-latest

--- a/build.sbt
+++ b/build.sbt
@@ -19,6 +19,11 @@ sourceDistIncubating := false
 
 ThisBuild / reproducibleBuildsCheckResolver := Resolver.ApacheMavenStagingRepo
 
+ThisBuild / javafmtFormatterCompatibleJavaVersion := 17
+
+addCommandAlias("checkCodeStyle", "scalafmtCheckAll; scalafmtSbtCheck; javafmtCheckAll; +headerCheckAll")
+addCommandAlias("applyCodeStyle", "+headerCreateAll; scalafmtAll; scalafmtSbt; javafmtAll")
+
 Test / unmanagedSourceDirectories ++= {
   if (scalaVersion.value.startsWith("2.")) {
     Seq(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -10,6 +10,7 @@
 addSbtPlugin("com.github.sbt" % "sbt-header" % "5.11.0")
 addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.3.1")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.6.1")
+addSbtPlugin("com.github.sbt" % "sbt-java-formatter" % "0.12.0")
 addSbtPlugin("com.github.pjfanning" % "sbt-source-dist" % "0.1.13")
 addSbtPlugin("com.github.pjfanning" % "sbt-pekko-build" % "0.4.7")
 addSbtPlugin("com.github.sbt" % "sbt-dynver" % "5.1.1")


### PR DESCRIPTION
## Summary
- Add sbt-java-formatter 0.12.0 plugin
- Add `ThisBuild / javafmtFormatterCompatibleJavaVersion := 17`
- Standardize `checkCodeStyle` and `applyCodeStyle` aliases
- Add check-code-style job to CI workflow

## Test plan
- [ ] CI check-code-style job passes
- [ ] CI check-code-compilation job passes
- [ ] CI test job passes