### PR TITLE
Improve Scala 3.8 forward compatibility

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -58,7 +58,17 @@ lazy val root = Project(
       "com.dimafeng" %% "testcontainers-scala-scalatest" % testcontainersScalaVersion % Test),
     scalacOptions ++= Seq("-deprecation", "-feature"),
     scalacOptions ++= {
-      if (scalaBinaryVersion.value == "3") Seq("-Yfuture-lazy-vals", "-release:17")
+      if (scalaBinaryVersion.value == "3")
+        Seq(
+          "-Yfuture-lazy-vals",
+          "-release:17",
+          "-Wconf:msg=Implicit parameters should be provided with a `using` clause:s",
+          "-Wconf:msg=is deprecated for wildcard arguments of types:s",
+          "-Wconf:msg=The trailing ` _` for eta-expansion is unnecessary:s",
+          "-Wconf:msg=with as a type operator has been deprecated:s",
+          "-Wconf:msg=Unreachable case except for null:s",
+          "-Wconf:msg=is no longer supported for vararg splices:s",
+          "-Wconf:msg=bad option.*-Yfuture-lazy-vals:s")
       else Seq.empty
     },
     Test / parallelExecution := false,

--- a/src/main/scala/org/apache/pekko/persistence/dynamodb/journal/DynamoDBHelper.scala
+++ b/src/main/scala/org/apache/pekko/persistence/dynamodb/journal/DynamoDBHelper.scala
@@ -74,7 +74,7 @@ trait DynamoDBHelper {
 
   def shutdown(): Unit = dynamoDB.shutdown()
 
-  private var reporter: ActorRef = _
+  private var reporter: ActorRef = null
   def setReporter(ref: ActorRef): Unit = reporter = ref
 
   private def send[In <: AmazonWebServiceRequest, Out](aws: In, func: AsyncHandler[In, Out] => juc.Future[Out])(implicit

--- a/src/test/scala/org/apache/pekko/persistence/dynamodb/journal/DynamoDBIntegrationLoadSpec.scala
+++ b/src/test/scala/org/apache/pekko/persistence/dynamodb/journal/DynamoDBIntegrationLoadSpec.scala
@@ -84,7 +84,7 @@ pekko.persistence.snapshot-store.plugin = ""
   }
 
   class ProcessorC(val persistenceId: String, probe: ActorRef) extends PersistentActor {
-    var last: String = _
+    var last: String = null
 
     def receiveRecover: Receive = {
       case SnapshotOffer(_, snapshot: String) =>

--- a/src/test/scala/org/apache/pekko/persistence/dynamodb/snapshot/SnapshotTooBigSpec.scala
+++ b/src/test/scala/org/apache/pekko/persistence/dynamodb/snapshot/SnapshotTooBigSpec.scala
@@ -50,7 +50,7 @@ class SnapshotTooBigSpec extends TestKit(ActorSystem("SnapshotTooBigSpec"))
     client.shutdown()
   }
 
-  private var senderProbe: TestProbe = _
+  private var senderProbe: TestProbe = null
   val persistenceId = "SnapshotTooBigSpec"
   val snapshotStore = Persistence(system).snapshotStoreFor("")
 


### PR DESCRIPTION
## Summary
- Replace `= _` with `= null` in 3 locations (deprecated in Scala 3.8)
- Add `-Wconf` suppressions for warnings requiring Scala 3-only syntax fixes (using clauses, wildcard types, eta-expansion, with operator, vararg splices)
- Zero new warnings when compiled with Scala 3.8.4, while maintaining full cross-compilation with Scala 2.13 and 3.3.x

## Test plan
- [x] Verified clean compilation with Scala 3.8.4 (zero new warnings)
- [ ] CI passes on Scala 2.13 and 3.3.x