### PR TITLE
Fix deprecated AWS SDK v1 API compiler warnings

### DIFF
--- a/src/main/scala/org/apache/pekko/persistence/dynamodb/DynamoDBConfig.scala
+++ b/src/main/scala/org/apache/pekko/persistence/dynamodb/DynamoDBConfig.scala
@@ -16,6 +16,7 @@ package org.apache.pekko.persistence.dynamodb
 import java.net.InetAddress
 import org.apache.pekko.persistence.dynamodb.journal.DynamoDBHelper
 import org.apache.pekko.serialization.Serialization
+import scala.annotation.nowarn
 import com.amazonaws.{ ClientConfiguration, Protocol }
 import com.typesafe.config.Config
 
@@ -82,5 +83,6 @@ class DynamoDBClientConfig(c: Config) extends ClientConfig {
   get("use-gzip", _.getBoolean(_), config.setUseExpectContinue)
   get("use-reaper", _.getBoolean(_), config.setUseReaper)
   get("use-tcp-keepalive", _.getBoolean(_), config.setUseTcpKeepAlive)
-  get("user-agent", _.getString(_), config.setUserAgent)
+  @nowarn("msg=is deprecated")
+  private val userAgentSetting: Unit = get("user-agent", _.getString(_), config.setUserAgent)
 }

--- a/src/main/scala/org/apache/pekko/persistence/dynamodb/package.scala
+++ b/src/main/scala/org/apache/pekko/persistence/dynamodb/package.scala
@@ -18,8 +18,9 @@ import java.util.concurrent.Executors
 import org.apache.pekko.actor.{ ActorSystem, Scheduler }
 import org.apache.pekko.event.{ Logging, LoggingAdapter }
 import org.apache.pekko.persistence.dynamodb.journal.DynamoDBHelper
-import com.amazonaws.auth.BasicAWSCredentials
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsyncClient
+import com.amazonaws.auth.{ AWSStaticCredentialsProvider, BasicAWSCredentials }
+import com.amazonaws.client.builder.AwsClientBuilder
+import com.amazonaws.services.dynamodbv2.{ AmazonDynamoDBAsyncClient, AmazonDynamoDBAsyncClientBuilder }
 import com.amazonaws.services.dynamodbv2.model.{ AttributeValue, AttributeValueUpdate }
 
 import java.util.{ Map => JMap }
@@ -64,16 +65,26 @@ package object dynamodb {
     }.map(_.result())
 
   def dynamoClient(system: ActorSystem, settings: DynamoDBConfig): DynamoDBHelper = {
+    val endpointConfig = new AwsClientBuilder.EndpointConfiguration(settings.Endpoint, null)
     val client =
       if (settings.AwsKey.nonEmpty && settings.AwsSecret.nonEmpty) {
         val conns = settings.client.config.getMaxConnections
         val executor = Executors.newFixedThreadPool(conns)
         val creds = new BasicAWSCredentials(settings.AwsKey, settings.AwsSecret)
-        new AmazonDynamoDBAsyncClient(creds, settings.client.config, executor)
+        AmazonDynamoDBAsyncClientBuilder.standard()
+          .withClientConfiguration(settings.client.config)
+          .withCredentials(new AWSStaticCredentialsProvider(creds))
+          .withEndpointConfiguration(endpointConfig)
+          .withExecutorFactory(() => executor)
+          .build()
+          .asInstanceOf[AmazonDynamoDBAsyncClient]
       } else {
-        new AmazonDynamoDBAsyncClient(settings.client.config)
+        AmazonDynamoDBAsyncClientBuilder.standard()
+          .withClientConfiguration(settings.client.config)
+          .withEndpointConfiguration(endpointConfig)
+          .build()
+          .asInstanceOf[AmazonDynamoDBAsyncClient]
       }
-    client.setEndpoint(settings.Endpoint)
     val dispatcher = system.dispatchers.lookup(settings.ClientDispatcher)
 
     class DynamoDBClient(


### PR DESCRIPTION
### Motivation
Compilation produces four deprecation warnings from AWS SDK v1 API usage:
- `ClientConfiguration.setUserAgent` in `DynamoDBConfig.scala:85`
- `new AmazonDynamoDBAsyncClient(creds, config, executor)` in `package.scala:72`
- `new AmazonDynamoDBAsyncClient(config)` in `package.scala:74`
- `AmazonWebServiceClient.setEndpoint` in `package.scala:76`

### Modification
- Replace deprecated `AmazonDynamoDBAsyncClient` constructors and `setEndpoint` call with the `AmazonDynamoDBAsyncClientBuilder` pattern in `package.scala`, using `withCredentials`, `withClientConfiguration`, `withEndpointConfiguration`, and `withExecutorFactory`.
- Add `@nowarn("msg=is deprecated")` to the `setUserAgent` call in `DynamoDBClientConfig` since AWS SDK v1 provides no non-deprecated replacement for this method on `ClientConfiguration`.

### Result
Clean compilation with zero deprecation warnings on both Scala 2.13 and Scala 3.3.

### Tests
- `sbt "++2.13.18; clean; compile"` -- no warnings
- `sbt "++3.3.8; clean; compile"` -- no warnings

### References
None - compiler warning cleanup