### PR TITLE
Add sbt-salad-days to reduce Scaladoc archive size

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -15,3 +15,6 @@ addSbtPlugin("com.github.pjfanning" % "sbt-source-dist" % "0.1.13")
 addSbtPlugin("com.github.pjfanning" % "sbt-pekko-build" % "0.4.7")
 addSbtPlugin("com.github.sbt" % "sbt-dynver" % "5.1.1")
 addSbtPlugin("net.bzzt" % "sbt-reproducible-builds" % "0.32")
+
+// https://eed3si9n.com/reducing-scaladoc-file-size-with-sbt-salad-days/
+addSbtPlugin("com.eed3si9n" % "sbt-salad-days" % "0.1.0")


### PR DESCRIPTION
## Motivation

Scala 3 Scaladoc archives bundle large font files and `inkuire.js` search engine, bloating release artifacts and wasting CI storage and upload time.

## Modification

Add `sbt-salad-days` plugin (0.1.0) to `project/plugins.sbt`. The plugin operates automatically during Scaladoc packaging — strips fonts and scripts from the generated archives without requiring any additional configuration.

## Result

Significantly smaller Scaladoc archives (e.g. ~420KB for minimal docs), reducing storage consumption in CI/release pipelines.

## References

- Blog post: https://eed3si9n.com/reducing-scaladoc-file-size-with-sbt-salad-days/