### PR TITLE
refactor: replace deprecated ActorMaterializer with Materializer

### DIFF
--- a/src/test/scala-2/org/apache/pekko/persistence/dynamodb/journal/WriteThroughputBench.scala
+++ b/src/test/scala-2/org/apache/pekko/persistence/dynamodb/journal/WriteThroughputBench.scala
@@ -128,8 +128,7 @@ writer-dispatcher {
       .withFallback(ConfigFactory.load())
 
   implicit val system: ActorSystem = ActorSystem("WriteThroughputBench", config)
-  implicit val materializer: Materializer =
-    ActorMaterializer(ActorMaterializerSettings(system).withInputBuffer(1, 1))
+  implicit val materializer: Materializer = Materializer(system)
 
   /*
    * You will want to make sure that the table is deployed with the proper values for


### PR DESCRIPTION
### Motivation
`ActorMaterializer` and `ActorMaterializerSettings` have been deprecated since Akka 2.6.0 in favor of `Materializer.apply(system)`.

### Modification
Replace `ActorMaterializer(ActorMaterializerSettings(system).withInputBuffer(1, 1))` with `Materializer(system)` in `WriteThroughputBench.scala`.

### Result
Removes usage of deprecated `ActorMaterializer` API.

### Tests
- Not run — benchmark file only

### References
None — deprecated API cleanup