### PR TITLE
build: enable -Xfatal-warnings for Scala 2 and -Werror for Scala 3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -56,10 +56,11 @@ lazy val root = Project(
       "commons-io" % "commons-io" % "2.22.0" % Test,
       "org.hdrhistogram" % "HdrHistogram" % "2.2.2" % Test,
       "com.dimafeng" %% "testcontainers-scala-scalatest" % testcontainersScalaVersion % Test),
-    scalacOptions ++= Seq("-deprecation", "-feature"),
+    scalacOptions ++= Seq("-deprecation", "-feature", "-Xfatal-warnings"),
     scalacOptions ++= {
       if (scalaBinaryVersion.value == "3")
         Seq(
+          "-Werror",
           "-Yfuture-lazy-vals",
           "-release:17",
           "-Wconf:msg=Implicit parameters should be provided with a `using` clause:s",
@@ -68,9 +69,11 @@ lazy val root = Project(
           "-Wconf:msg=with as a type operator has been deprecated:s",
           "-Wconf:msg=Unreachable case except for null:s",
           "-Wconf:msg=is no longer supported for vararg splices:s",
-          "-Wconf:msg=bad option.*-Yfuture-lazy-vals:s")
+          "-Wconf:msg=bad option.*-Yfuture-lazy-vals:s",
+          "-Wconf:msg=bad option.*-Xfatal-warnings:s")
       else Seq.empty
     },
+    Compile / doc / scalacOptions --= Seq("-Xfatal-warnings"),
     Test / parallelExecution := false,
     // required by test-containers-scala
     Test / fork := true,


### PR DESCRIPTION
### Motivation
Treating warnings as errors ensures that deprecated API usage and other code quality issues are caught at compile time rather than accumulating silently.

### Modification
- Add `-Xfatal-warnings` to main `scalacOptions` in `build.sbt`
- Add `-Werror` to Scala 3 `scalacOptions`
- Exclude `-Xfatal-warnings` from `Compile / doc` scope to avoid doc generation failures

### Result
All compiler warnings are now treated as errors, enforcing higher code quality.

### Tests
- CI will verify compilation

### References
None — build configuration improvement