### PR TITLE
fix: fix scaladoc warnings in query module

### DIFF
--- a/src/main/scala/org/apache/pekko/persistence/dynamodb/query/javadsl/DynamoDBReadJournal.scala
+++ b/src/main/scala/org/apache/pekko/persistence/dynamodb/query/javadsl/DynamoDBReadJournal.scala
@@ -51,7 +51,7 @@ class DynamoDBReadJournal(scaladslReadJournal: scaladsl.DynamoDBReadJournal)
     {
 
   /**
-   * Same type of query as [[org.apache.pekko.persistence.query.javadsl.EventsByPersistenceIdQuery.eventsByPersistenceId]]
+   * Same type of query as `org.apache.pekko.persistence.query.javadsl.EventsByPersistenceIdQuery.eventsByPersistenceId`
    * but the event stream is completed immediately when it reaches the end of
    * the results. Events that are stored after the query is completed are
    * not included in the event stream.
@@ -67,7 +67,7 @@ class DynamoDBReadJournal(scaladslReadJournal: scaladsl.DynamoDBReadJournal)
     scaladslReadJournal.currentEventsByPersistenceId(persistenceId, fromSequenceNr, toSequenceNr).asJava
 
   /**
-   * Same type of query as [[org.apache.pekko.persistence.query.javadsl.PersistenceIdsQuery.persistenceIds()]] but the stream
+   * Same type of query as `org.apache.pekko.persistence.query.javadsl.PersistenceIdsQuery.persistenceIds()` but the stream
    * is completed immediately when it reaches the end of the "result set". Persistent
    * actors that are created after the query is completed are not included in the stream.
    *

--- a/src/main/scala/org/apache/pekko/persistence/dynamodb/query/scaladsl/DynamoDBCurrentEventsByPersistenceIdQuery.scala
+++ b/src/main/scala/org/apache/pekko/persistence/dynamodb/query/scaladsl/DynamoDBCurrentEventsByPersistenceIdQuery.scala
@@ -17,7 +17,7 @@ import org.apache.pekko.stream.scaladsl.Source
 trait DynamoDBCurrentEventsByPersistenceIdQuery extends CurrentEventsByPersistenceIdQuery {
 
   /**
-   * Same type of query as [[org.apache.pekko.persistence.query.scaladsl.EventsByPersistenceIdQuery.eventsByPersistenceId]]
+   * Same type of query as `org.apache.pekko.persistence.query.scaladsl.EventsByPersistenceIdQuery.eventsByPersistenceId`
    * but the event stream is completed immediately when it reaches the end of
    * the results. Events that are stored after the query is completed are
    * not included in the event stream.

--- a/src/main/scala/org/apache/pekko/persistence/dynamodb/query/scaladsl/DynamoDBCurrentPersistenceIdsQuery.scala
+++ b/src/main/scala/org/apache/pekko/persistence/dynamodb/query/scaladsl/DynamoDBCurrentPersistenceIdsQuery.scala
@@ -22,7 +22,7 @@ import scala.concurrent.Future
 trait DynamoDBCurrentPersistenceIdsQuery extends CurrentPersistenceIdsQuery {
 
   /**
-   * Same type of query as [[org.apache.pekko.persistence.query.scaladsl.PersistenceIdsQuery.persistenceIds()]] but the stream
+   * Same type of query as `org.apache.pekko.persistence.query.scaladsl.PersistenceIdsQuery.persistenceIds()` but the stream
    * is completed immediately when it reaches the end of the "result set". Persistent
    * actors that are created after the query is completed are not included in the stream.
    *

--- a/src/main/scala/org/apache/pekko/persistence/dynamodb/query/scaladsl/internal/DynamoDBCurrentEventsByPersistenceIdQuery.scala
+++ b/src/main/scala/org/apache/pekko/persistence/dynamodb/query/scaladsl/internal/DynamoDBCurrentEventsByPersistenceIdQuery.scala
@@ -40,7 +40,7 @@ trait DynamoDBCurrentEventsByPersistenceIdQuery
     with SerializationProvider =>
 
   /**
-   * Same type of query as [[org.apache.pekko.persistence.query.scaladsl.EventsByPersistenceIdQuery.eventsByPersistenceId]]
+   * Same type of query as `org.apache.pekko.persistence.query.scaladsl.EventsByPersistenceIdQuery.eventsByPersistenceId`
    * but the event stream is completed immediately when it reaches the end of
    * the results. Events that are stored after the query is completed are
    * not included in the event stream.

--- a/src/main/scala/org/apache/pekko/persistence/dynamodb/query/scaladsl/internal/DynamoDBCurrentPersistenceIdsQuery.scala
+++ b/src/main/scala/org/apache/pekko/persistence/dynamodb/query/scaladsl/internal/DynamoDBCurrentPersistenceIdsQuery.scala
@@ -39,7 +39,7 @@ trait DynamoDBCurrentPersistenceIdsQuery extends PublicDynamoDBCurrentPersistenc
     with JournalKeys =>
 
   /**
-   * Same type of query as [[org.apache.pekko.persistence.query.scaladsl.PersistenceIdsQuery.persistenceIds()]] but the stream
+   * Same type of query as `org.apache.pekko.persistence.query.scaladsl.PersistenceIdsQuery.persistenceIds()` but the stream
    * is completed immediately when it reaches the end of the "result set". Persistent
    * actors that are created after the query is completed are not included in the stream.
    *


### PR DESCRIPTION
### Motivation
Running `sbt doc` produces scaladoc warnings about unresolvable method links in the query module.

### Modification
- `query/javadsl/DynamoDBReadJournal.scala`: Replace broken method links with backtick-quoted code
- `query/scaladsl/DynamoDBCurrentEventsByPersistenceIdQuery.scala`: Replace broken method link with backtick-quoted code
- `query/scaladsl/DynamoDBCurrentPersistenceIdsQuery.scala`: Replace broken method link with backtick-quoted code
- `query/scaladsl/internal/DynamoDBCurrentEventsByPersistenceIdQuery.scala`: Replace broken method link with backtick-quoted code
- `query/scaladsl/internal/DynamoDBCurrentPersistenceIdsQuery.scala`: Replace broken method link with backtick-quoted code

### Result
Scaladoc warnings are eliminated.

### Tests
Not run - docs only

### References
None