### PR TITLE
feat: add Scala 3.8.4 cross-compilation target

### DIFF
--- a/.github/workflows/check-build-test.yml
+++ b/.github/workflows/check-build-test.yml
@@ -84,6 +84,7 @@ jobs:
         include:
           - { java-version: 17,  scala-version: 2.13, sbt-opts: '' }
           - { java-version: 17,  scala-version: 3.3, sbt-opts: '' }
+          - { java-version: 17,  scala-version: 3.8, sbt-opts: '' }
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/build.sbt
+++ b/build.sbt
@@ -46,7 +46,7 @@ lazy val root = Project(
   .settings(
     name := "pekko-persistence-dynamodb",
     scalaVersion := "2.13.18",
-    crossScalaVersions := Seq("2.13.18", "3.3.8"),
+    crossScalaVersions := Seq("2.13.18", "3.3.8", "3.8.4"),
     crossVersion := CrossVersion.binary,
     libraryDependencies ++= Seq(
       "com.amazonaws" % "aws-java-sdk-core" % amzVersion,


### PR DESCRIPTION
### Motivation
Ensure pekko-persistence-dynamodb compiles and tests pass on the next Scala 3 release line (3.8.x), preparing for future Scala 3.9.x compatibility.

### Modification
- Add `"3.8.4"` to `crossScalaVersions` in build.sbt
- Add `"3.8"` to CI matrix in check-build-test.yml

### Result
CI now compiles and tests against Scala 2.13, 3.3, and 3.8. Publishing continues with Scala 3.3.8.

### Tests
CI will validate

### References
None - proactive compatibility testing