### PR TITLE
fix: fix deprecation warnings in DynamoDB client code and tests

### DIFF
--- a/src/main/scala/org/apache/pekko/persistence/dynamodb/DynamoDBConfig.scala
+++ b/src/main/scala/org/apache/pekko/persistence/dynamodb/DynamoDBConfig.scala
@@ -82,5 +82,5 @@ class DynamoDBClientConfig(c: Config) extends ClientConfig {
   get("use-gzip", _.getBoolean(_), config.setUseExpectContinue)
   get("use-reaper", _.getBoolean(_), config.setUseReaper)
   get("use-tcp-keepalive", _.getBoolean(_), config.setUseTcpKeepAlive)
-  get("user-agent", _.getString(_), config.setUserAgent)
+  get("user-agent", _.getString(_), config.setUserAgentPrefix)
 }

--- a/src/main/scala/org/apache/pekko/persistence/dynamodb/journal/DynamoDBHelper.scala
+++ b/src/main/scala/org/apache/pekko/persistence/dynamodb/journal/DynamoDBHelper.scala
@@ -15,7 +15,7 @@ package org.apache.pekko.persistence.dynamodb.journal
 
 import com.amazonaws.{ AmazonServiceException, AmazonWebServiceRequest }
 import com.amazonaws.handlers.AsyncHandler
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsyncClient
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsync
 import com.amazonaws.services.dynamodbv2.model._
 import org.apache.pekko
 import pekko.actor.{ ActorRef, Scheduler }
@@ -67,7 +67,7 @@ trait DynamoDBHelper {
 
   implicit val ec: ExecutionContext
   val scheduler: Scheduler
-  val dynamoDB: AmazonDynamoDBAsyncClient
+  val dynamoDB: AmazonDynamoDBAsync
   val log: LoggingAdapter
   val settings: DynamoDBConfig
   import settings._

--- a/src/main/scala/org/apache/pekko/persistence/dynamodb/package.scala
+++ b/src/main/scala/org/apache/pekko/persistence/dynamodb/package.scala
@@ -18,8 +18,10 @@ import java.util.concurrent.Executors
 import org.apache.pekko.actor.{ ActorSystem, Scheduler }
 import org.apache.pekko.event.{ Logging, LoggingAdapter }
 import org.apache.pekko.persistence.dynamodb.journal.DynamoDBHelper
-import com.amazonaws.auth.BasicAWSCredentials
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsyncClient
+import com.amazonaws.auth.{ AWSStaticCredentialsProvider, BasicAWSCredentials }
+import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration
+import com.amazonaws.client.builder.ExecutorFactory
+import com.amazonaws.services.dynamodbv2.{ AmazonDynamoDBAsync, AmazonDynamoDBAsyncClientBuilder }
 import com.amazonaws.services.dynamodbv2.model.{ AttributeValue, AttributeValueUpdate }
 
 import java.util.{ Map => JMap }
@@ -64,21 +66,26 @@ package object dynamodb {
     }.map(_.result())
 
   def dynamoClient(system: ActorSystem, settings: DynamoDBConfig): DynamoDBHelper = {
-    val client =
+    val client = {
+      val builder = AmazonDynamoDBAsyncClientBuilder.standard()
+        .withClientConfiguration(settings.client.config)
+        .withEndpointConfiguration(new EndpointConfiguration(settings.Endpoint, "us-east-1"))
       if (settings.AwsKey.nonEmpty && settings.AwsSecret.nonEmpty) {
         val conns = settings.client.config.getMaxConnections
         val executor = Executors.newFixedThreadPool(conns)
         val creds = new BasicAWSCredentials(settings.AwsKey, settings.AwsSecret)
-        new AmazonDynamoDBAsyncClient(creds, settings.client.config, executor)
+        builder.withCredentials(new AWSStaticCredentialsProvider(creds))
+          .withExecutorFactory(new ExecutorFactory { override def newExecutor() = executor })
+          .build()
       } else {
-        new AmazonDynamoDBAsyncClient(settings.client.config)
+        builder.build()
       }
-    client.setEndpoint(settings.Endpoint)
+    }
     val dispatcher = system.dispatchers.lookup(settings.ClientDispatcher)
 
     class DynamoDBClient(
         override val ec: ExecutionContext,
-        override val dynamoDB: AmazonDynamoDBAsyncClient,
+        override val dynamoDB: AmazonDynamoDBAsync,
         override val settings: DynamoDBConfig,
         override val scheduler: Scheduler,
         override val log: LoggingAdapter)

--- a/src/test/scala-2/org/apache/pekko/persistence/dynamodb/journal/WriteThroughputBench.scala
+++ b/src/test/scala-2/org/apache/pekko/persistence/dynamodb/journal/WriteThroughputBench.scala
@@ -128,8 +128,7 @@ writer-dispatcher {
       .withFallback(ConfigFactory.load())
 
   implicit val system: ActorSystem = ActorSystem("WriteThroughputBench", config)
-  implicit val materializer: Materializer =
-    ActorMaterializer(ActorMaterializerSettings(system).withInputBuffer(1, 1))
+  implicit val materializer: Materializer = Materializer(system)
 
   /*
    * You will want to make sure that the table is deployed with the proper values for
@@ -179,6 +178,7 @@ writer-dispatcher {
         zip.out                             ~> Sink.foreach(printStats)
         ClosedShape
       })
+      .withAttributes(Attributes.inputBuffer(1, 1))
       .run()
 
   println(s"starting $writers writers")

--- a/src/test/scala/org/apache/pekko/persistence/dynamodb/journal/BackwardsCompatibilityV1Spec.scala
+++ b/src/test/scala/org/apache/pekko/persistence/dynamodb/journal/BackwardsCompatibilityV1Spec.scala
@@ -18,10 +18,10 @@ import org.apache.pekko.persistence.JournalProtocol._
 import org.apache.pekko.persistence._
 import org.apache.pekko.persistence.dynamodb.IntegSpec
 import org.apache.pekko.testkit._
-import com.amazonaws.auth.BasicAWSCredentials
-import com.amazonaws.regions.Regions
+import com.amazonaws.auth.{ AWSStaticCredentialsProvider, BasicAWSCredentials }
+import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration
 import com.amazonaws.services.dynamodbv2.document.{ DynamoDB, Item }
-import com.amazonaws.services.dynamodbv2.{ AmazonDynamoDB, AmazonDynamoDBClient }
+import com.amazonaws.services.dynamodbv2.{ AmazonDynamoDB, AmazonDynamoDBClientBuilder }
 import com.typesafe.config.ConfigFactory
 import org.scalactic.TypeCheckedTripleEquals
 import org.scalatest.BeforeAndAfterAll
@@ -50,9 +50,10 @@ class BackwardsCompatibilityV1Spec
     val secretKey = config.getString("my-dynamodb-journal.aws-secret-access-key")
 
     val client: AmazonDynamoDB =
-      new AmazonDynamoDBClient(new BasicAWSCredentials(accesKey, secretKey)).withRegion(Regions.US_EAST_1)
-
-    client.setEndpoint(endpoint)
+      AmazonDynamoDBClientBuilder.standard()
+        .withCredentials(new AWSStaticCredentialsProvider(new BasicAWSCredentials(accesKey, secretKey)))
+        .withEndpointConfiguration(new EndpointConfiguration(endpoint, "us-east-1"))
+        .build()
 
     val dynamoDB = new DynamoDB(client)
 

--- a/src/test/scala/org/apache/pekko/persistence/dynamodb/journal/FailureReportingSpec.scala
+++ b/src/test/scala/org/apache/pekko/persistence/dynamodb/journal/FailureReportingSpec.scala
@@ -55,7 +55,7 @@ class FailureReportingSpec
     (rej.cause.getMessage should include).regex(msg)
   }
 
-  def expectFailure[T: Manifest](msg: String, repr: PersistentRepr) = {
+  def expectFailure[T: scala.reflect.ClassTag](msg: String, repr: PersistentRepr) = {
     val rej = expectMsgType[WriteMessageFailure]
     rej.message should ===(repr)
     rej.cause shouldBe a[T]


### PR DESCRIPTION
### Motivation
Several deprecated AWS SDK v1 APIs and Scala APIs were used, causing deprecation warnings on Scala 2.13, 3.3 and 3.8 cross-builds.

### Modification
- Replace deprecated `AmazonDynamoDBAsyncClient` constructors with `AmazonDynamoDBAsyncClientBuilder` pattern
- Replace deprecated `setEndpoint`/`withRegion` with `EndpointConfiguration`
- Replace deprecated `ClientConfiguration.setUserAgent` with `setUserAgentPrefix`
- Replace deprecated `ActorMaterializer` with `Materializer(system)` and move input buffer config to stream `Attributes`
- Replace deprecated `Manifest` context bound with `ClassTag` in test
- Widen `DynamoDBHelper.dynamoDB` type from `AmazonDynamoDBAsyncClient` to `AmazonDynamoDBAsync` interface

### Result
Clean compilation with zero deprecation warnings across all Scala versions (2.13.18, 3.3.8, 3.8.4).

### Tests
- `sbt +test:compile` - all versions pass with no warnings

### References
None - code quality improvement